### PR TITLE
Catch error event and prevent bot from crashing

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,4 +35,6 @@ bot.on("message", message => {
   role.onMessage(message, bot);
 });
 
+bot.on("error", console.error);
+
 bot.login(config.token);


### PR DESCRIPTION
Catch error so that bot doesn't crash next time and we can have an opportunity to figure out how to handle errors.